### PR TITLE
Revert "Ignore MUC Cleaner tests for Totara."

### DIFF
--- a/cleaner/muc/tests/phpunit/cleaner_muc_testcase.php
+++ b/cleaner/muc/tests/phpunit/cleaner_muc_testcase.php
@@ -75,14 +75,4 @@ class local_datacleaner_cleaner_muc_testcase extends advanced_testcase {
         muc_config_db::save($config);
         return $config;
     }
-
-    protected function setUp() {
-        global $CFG;
-
-        parent::setUp();
-
-        if (isset($CFG->totara_version)) {
-            $this->markTestSkipped('Our unit tests are not compatible with Totara.');
-        }
-    }
 }


### PR DESCRIPTION
This reverts commit baca78e2435a22e2db871d1cebcb1cec2499c2b8.

The bug was not only in Totara, see MDL-59595.