### PR TITLE
Fetching parameters from database in users_cleaner

### DIFF
--- a/cleaner/users/classes/clean.php
+++ b/cleaner/users/classes/clean.php
@@ -62,7 +62,8 @@ class clean extends \local_datacleaner\clean {
 
         echo "Fetching users to update...\n";
 
-        $criteria = self::get_user_criteria(static::$options);
+        $config = get_config('cleaner_delete_users');
+        $criteria = self::get_user_criteria($config);
         list($where, $whereparams) = self::get_user_where_sql($criteria);
 
         $ids = $DB->get_records_select('user', 'id > 2 '.$where, $whereparams, 'id', 'id');


### PR DESCRIPTION
"Ok so, when run using CLI, the configuration is ignored/not loaded so in order to scramble admin users, I had to force $keepsiteadmins = false; in datacleaner/classes/clean.php (~l.182).

A clean way would be to set up all the $config from DB values when executed through CLI..."

This commit is fixing this issue.