### PR TITLE
WR #307395: implement tearDown for backup_cleaner_test

### DIFF
--- a/cleaner/orphaned_sitedata/tests/unit/backup_cleaner_test.php
+++ b/cleaner/orphaned_sitedata/tests/unit/backup_cleaner_test.php
@@ -50,6 +50,11 @@ class backup_cleaner_test extends orphaned_sitedata_testcase {
         $this->initialfiles = $this->get_files();
     }
 
+    public function tearDown() {
+        unset($this->initialfiles);
+        parent::tearDown();
+    }
+
     public function test_it_exists() {
         $cleaner = new backup_cleaner(true);
         self::assertNotNull($cleaner);


### PR DESCRIPTION
Causing unit tests to fail for Totara 12