### PR TITLE
Master fix unset

### DIFF
--- a/cleaner/orphaned_sitedata/tests/unit/backup_cleaner_test.php
+++ b/cleaner/orphaned_sitedata/tests/unit/backup_cleaner_test.php
@@ -51,7 +51,7 @@ class backup_cleaner_test extends orphaned_sitedata_testcase {
     }
 
     public function tearDown() {
-        unset($this->initialfiles);
+        $this->initialfiles = null;
         parent::tearDown();
     }
 

--- a/cleaner/replace_urls/tests/replace_urls_test.php
+++ b/cleaner/replace_urls/tests/replace_urls_test.php
@@ -58,6 +58,7 @@ class cleaner_replace_urls_test extends advanced_testcase {
      * Teardown unit tests.
      */
     protected function tearDown() {
+        $this->course = null;
         parent::tearDown();
     }
 


### PR DESCRIPTION
There is coding error and test failure in datacleaner testsuite
```
There was 1 error:

1) cleaner_orphaned_sitedata\tests\unit\backup_cleaner_test::test_it_exists
Undefined property: cleaner_orphaned_sitedata\tests\unit\backup_cleaner_test::$initialfiles

/var/www/site/lib/phpunit/classes/advanced_testcase.php:517
/var/www/site/lib/phpunit/classes/advanced_testcase.php:105

To re-run:
 vendor/bin/phpunit cleaner_orphaned_sitedata\tests\unit\backup_cleaner_test local/datacleaner/cleaner/orphaned_sitedata/tests/unit/backup_cleaner_test.php
```

```
There was 1 failure:

1) cleaner_replace_urls_test::test_replace_url
Property 'course' defined in 'cleaner_replace_urls_test' was not reset after the test!
Please either find a way to avoid using a class variable or make sure it get's unset in the tearDown method to avoid creating memory leaks.

/var/www/site/lib/phpunit/classes/advanced_testcase.php:521
/var/www/site/lib/phpunit/classes/advanced_testcase.php:105

To re-run:
 vendor/bin/phpunit cleaner_replace_urls_test local/datacleaner/cleaner/replace_urls/tests/replace_urls_test.php
```

