### PR TITLE
WR# 315858 Fix for environment matrix cleaner

### DIFF
--- a/cleaner/environment_matrix/README.md
+++ b/cleaner/environment_matrix/README.md
@@ -4,7 +4,7 @@ Use
 ---
 This subplugin will swap configurations in the admin settings, depending on the environment that the wash is being run on. Configure the environments in production, and the configs that need to be swapped, and during refresh, the data will be swapped in.
 
-The plugin searches the admin tree for controls that match the config object that needs to be swapped out. When a matching config control is found, the plugin attempts to use the write_setting() function of the control to update the values. Some admin controls may expect data of a different type in write_setting(), such as an array. If the write_setting fails to run, due to mismatch in data types, the plugin instead falls back to using set_config(), to modify the database correctly, so the config will always be written.
+The plugin uses set_config to update the database with the new configuration, then it constructs an admin_settings tree, to get the updated value back out in a format that the admin_setting can use. After this, it passes that value back in, using write_setting, to perform any addition checks, validation, or custom functionality that controls, including custom controls, that may be required.
 
 Testing
 -------

--- a/cleaner/environment_matrix/README.md
+++ b/cleaner/environment_matrix/README.md
@@ -1,0 +1,24 @@
+# Environment Matrix Cleaner
+
+Use
+---
+This subplugin will swap configurations in the admin settings, depending on the environment that the wash is being run on. Configure the environments in production, and the configs that need to be swapped, and during refresh, the data will be swapped in.
+
+The plugin searches the admin tree for controls that match the config object that needs to be swapped out. When a matching config control is found, the plugin attempts to use the write_setting() function of the control to update the values. Some admin controls may expect data of a different type in write_setting(), such as an array. If the write_setting fails to run, due to mismatch in data types, the plugin instead falls back to using set_config(), to modify the database correctly, so the config will always be written.
+
+Testing
+-------
+
+| Config                                | Type                      | Action                                                   | Status  |
+|---------------------------------------|---------------------------|----------------------------------------------------------|---------|
+|core:profileroles                      | config_multicheckbox      | Requires array for write_setting, defaults to set_config | WORKING |
+|core:lockoutwindow                     | config_duration           | Requires array for write_setting, defaults to set_config | WORKING |
+|core:passwordpolicy                    | config_checkbox           | Set using write_setting                                  | WORKING |
+|core:maxbytes                          | config_select             | Requires array for write_setting, defaults to set_config | WORKING |
+|core:userquota                         | config_text               | Set using write_setting                                  | WORKING |         
+|tool_securityquestions:questionfile    | config_text               | Set using write_setting                                  | WORKING |
+|tool_securityquestions:questionduration| config_duration           | Requires array for write_setting, defaults to set_config | WORKING |
+|auth_saml2:idpmetadata                 | custom_config_idpmetadata | Set using write_setting, correctly updates IDP list      | WORKING |
+|auth_saml2:idpname                     | config_text               | Set using write_setting                                  | WORKING |
+|auth_saml2:showidplink                 | config_select             | Requires array for write_setting, defaults to set_config | WORKING |
+

--- a/cleaner/environment_matrix/classes/clean.php
+++ b/cleaner/environment_matrix/classes/clean.php
@@ -96,7 +96,14 @@ class clean extends \local_datacleaner\clean {
                         }
 
                         if (!$dryrun) {
-                            set_config($config->config, $config->value, $config->plugin);
+
+                            $classname = $config->plugin.'\admin\setting_'.$config->config;
+                            if (class_exists($classname)) {
+                                $configobject = new $classname;
+                                $configobject->write_setting($config->value);
+                            } else {
+                                set_config($config->config, $config->value, $config->plugin);
+                            }
                         }
 
                     }

--- a/cleaner/environment_matrix/version.php
+++ b/cleaner/environment_matrix/version.php
@@ -28,8 +28,8 @@ if (!defined('MOODLE_INTERNAL')) {
     die('Direct access to this script is forbidden.'); // It must be included from a Moodle page.
 }
 
-$plugin->version   = 2017053000;
-$plugin->release   = 2017053000;
+$plugin->version   = 2019082700;
+$plugin->release   = 2019082700;
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->requires  = 2013111800; // Moodle 2.6 release and upwards.
 $plugin->component = 'cleaner_environment_matrix';


### PR DESCRIPTION
Fixes issues where custom admin_setting controls are used, and additional actions/validation isnt fired when swapping config