### PR TITLE
Fix unit test

### DIFF
--- a/cleaner/email/tests/cleaner_email_test.php
+++ b/cleaner/email/tests/cleaner_email_test.php
@@ -104,8 +104,7 @@ class cleaner_email_test extends advanced_testcase {
 
         // Obtain the list of generated users.
         foreach ($this->users as $user) {
-            //$this->assertStringNotContainsString('.test', $user->email);
-            self::assertNotContains('.test', $user->email);
+            $this->assertStringNotContainsString('.test', $user->email);
         }
 
         // Lets clean!


### PR DESCRIPTION

Error:

```
1) cleaner_email_test::test_cleaner_email_suffix_ignore
TypeError: Argument 2 passed to PHPUnit\Framework\Assert::assertNotContains() must be iterable, string given, called in /var/www/site/server/local/datacleaner/cleaner/email/tests/cleaner_email_test.php on line 108

/var/www/site/server/local/datacleaner/cleaner/email/tests/cleaner_email_test.php:108
/var/www/site/server/lib/phpunit/classes/testcase.php:114
phpvfscomposer:///var/www/site/test/phpunit/vendor/phpunit/phpunit/phpunit:97
```

