### PR TITLE
issue #169: Add default settings for cleaner_custom_sql_pre and _post

### DIFF
--- a/cleaner/custom_sql_post/settings.php
+++ b/cleaner/custom_sql_post/settings.php
@@ -29,4 +29,4 @@ if (!$ADMIN->fulltree) {
 
 $settings->add(new admin_setting_configtextarea('cleaner_custom_sql_post/sql',
             new lang_string('sql', 'cleaner_custom_sql_post'),
-            new lang_string('sqldesc', 'cleaner_custom_sql_post'), null, PARAM_RAW));
+            new lang_string('sqldesc', 'cleaner_custom_sql_post'), '', PARAM_RAW));

--- a/cleaner/custom_sql_pre/settings.php
+++ b/cleaner/custom_sql_pre/settings.php
@@ -29,4 +29,4 @@ if (!$ADMIN->fulltree) {
 
 $settings->add(new admin_setting_configtextarea('cleaner_custom_sql_pre/sql',
             new lang_string('sql', 'cleaner_custom_sql_pre'),
-            new lang_string('sqldesc', 'cleaner_custom_sql_pre'), null, PARAM_RAW));
+            new lang_string('sqldesc', 'cleaner_custom_sql_pre'), '', PARAM_RAW));


### PR DESCRIPTION
Added default value for settings, resolving the failing unit test in core. Doesn't a empty string cause a problem? No the following line will take care of the empty string: https://github.com/catalyst/moodle-local_datacleaner/blob/MOODLE_311_STABLE/classes/clean.php#L383C18-L383C18

<details>
<summary>Unit test result of test test_admin_output_new_settings_by_page on Moodle 4.3</summary>

```
root@c3e2c38a9c70:/var/www/vanilla-403# vendor/bin/phpunit --filter test_admin_output_new_settings_by_page Moodle 4.3.2+ (Build: 20240104), 40890bf181407b0a84990916070ff1b9b0357716
Php: 8.1.24, pgsql: 14.0 (Debian 14.0-1.pgdg110+1), OS: Linux 6.4.12-060412-generic x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 00:01.375, Memory: 366.00 MB

OK (1 test, 2 assertions)
root@c3e2c38a9c70:/var/www/vanilla-403# vendor/bin/phpunit --list-suites
Moodle 4.3.2+ (Build: 20240104), 40890bf181407b0a84990916070ff1b9b0357716
Php: 8.1.24, pgsql: 14.0 (Debian 14.0-1.pgdg110+1), OS: Linux 6.4.12-060412-generic x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.
```
</details>

<details>
<summary>Unit test result of testsuites cleaner_backup_testsuite, cleaner_config_testsuite, cleaner_email_testsuite, cleaner_orphaned_sitedata_testsuite, cleaner_replace_urls_testsuite, local_datacleaner_testsuite on Moodle 4.3</summary>

```
Moodle 4.3.2+ (Build: 20240104), 40890bf181407b0a84990916070ff1b9b0357716
Php: 8.1.24, pgsql: 14.0 (Debian 14.0-1.pgdg110+1), OS: Linux 6.4.12-060412-generic x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

..................................................                50 / 50 (100%)

Time: 00:04.641, Memory: 72.50 MB

OK (50 tests, 141 assertions)
```
</details>

Closes #169 



