### PR TITLE
Add lang string for 4.4

### DIFF
--- a/lang/en/local_datacleaner.php
+++ b/lang/en/local_datacleaner.php
@@ -23,6 +23,7 @@
  */
 
 $string['pluginname'] = 'Data cleaner';
+$string['subplugintype_cleaner'] = 'Data Cleaner';
 $string['subplugintype_cleaner_plural'] = 'Data Cleaners';
 $string['privacy:metadata'] = 'The local datacleaner plugin does not store any personal data.';
 $string['cachedef_courses'] = 'Course cache';


### PR DESCRIPTION
Adds a missing string that is showing up in a few unit tests in Moodle 4.4

```
tool_dataprivacy\metadata_registry_test::test_get_registry_metadata_count
Unexpected debugging() call detected.
Debugging: Invalid get_string() identifier: 'subplugintype_cleaner' or component 'local_datacleaner'. Perhaps you are missing $string['subplugintype_cleaner'] = ''; in /var/www/moodle-44/local/datacleaner/lang/en/local_datacleaner.php?
```

```
tool_dataprivacy\metadata_registry_test::test_get_registry_metadata_null_provider_details
Unexpected debugging() call detected.
Debugging: Invalid get_string() identifier: 'subplugintype_cleaner' or component 'local_datacleaner'. Perhaps you are missing $string['subplugintype_cleaner'] = ''; in /var/www/moodle-44/local/datacleaner/lang/en/local_datacleaner.php?
```


```
tool_dataprivacy\metadata_registry_test::test_get_registry_metadata_provider_details
Unexpected debugging() call detected.
Debugging: Invalid get_string() identifier: 'subplugintype_cleaner' or component 'local_datacleaner'. Perhaps you are missing $string['subplugintype_cleaner'] = ''; in /var/www/moodle-44/local/datacleaner/lang/en/local_datacleaner.php?
```