### PR TITLE
Moodle 4.5 deprecated print_error, use moodle_exception

### DIFF
--- a/index.php
+++ b/index.php
@@ -53,7 +53,7 @@ if ((!empty($hide) || !empty($show)) && confirm_sesskey()) {
     $state = empty($hide);
 
     if (!isset($plugins[$pluginname])) {
-        print_error('plugindoesnotexist', 'error');
+        throw new \moodle_exception('plugindoesnotexist', 'error');
     }
     set_config('enabled', $state, 'cleaner_' . $pluginname);
 }


### PR DESCRIPTION
- Final deprecation of `\print_error()`. Please use the `\moodle_exception` class instead. For more information see [MDL-74484](https://tracker.moodle.org/browse/MDL-74484)