### PR TITLE
Swap mtrace to debugging

### DIFF
--- a/classes/clean.php
+++ b/classes/clean.php
@@ -462,7 +462,7 @@ abstract class clean {
     public static function log($string) {
         global $CFG;
 
-        mtrace($string);
+        debugging($string, DEBUG_DEVELOPER);
 
         // Stash a copy into sitedir log file.
         if (!file_exists("{$CFG->dataroot}/datacleaner")) {


### PR DESCRIPTION
Avoid execution loop by swapping  `mtrace($string);` to `debugging($string, DEBUG_DEVELOPER);` as introduced in https://github.com/catalyst/moodle-local_datacleaner/commit/476e619f3ba9a7b7956beb686bf1e6bf70ccbd84 .