### PR TITLE
Closes #231: Bump version in MOODLE_500_STABLE

### DIFF
--- a/cleaner/replace_urls/db/upgrade.php
+++ b/cleaner/replace_urls/db/upgrade.php
@@ -29,7 +29,7 @@
  * @return bool
  */
 function xmldb_cleaner_replace_urls_upgrade($oldversion) {
-    if ($oldversion < 2026030800) {
+    if ($oldversion < 2026031900) {
         // Clear the default 'http://localhost' newsiteurl so it falls back to wwwroot.
         if (get_config('cleaner_replace_urls', 'newsiteurl') === 'http://localhost') {
             set_config('newsiteurl', '', 'cleaner_replace_urls');
@@ -40,7 +40,7 @@ function xmldb_cleaner_replace_urls_upgrade($oldversion) {
             set_config('origsiteurl', '', 'cleaner_replace_urls');
         }
 
-        upgrade_plugin_savepoint(true, 2026030800, 'cleaner', 'replace_urls');
+        upgrade_plugin_savepoint(true, 2026031900, 'cleaner', 'replace_urls');
     }
 
     return true;

--- a/cleaner/replace_urls/version.php
+++ b/cleaner/replace_urls/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2026030800;
-$plugin->release   = '2026030800';
+$plugin->version   = 2026031900;
+$plugin->release   = '2026031900';
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->requires  = 2011120500; // Moodle 2.2 release and upwards.
 $plugin->component = 'cleaner_replace_urls';


### PR DESCRIPTION
This should bump the version of cleaner_replace_urls to be greater than the MOODLE_311_STABLE branch