### PR TITLE
Issue #97: Fix failing SQL for deleting course contexts.

### DIFF
--- a/classes/clean.php
+++ b/classes/clean.php
@@ -381,6 +381,7 @@ abstract class clean {
             $params = array_merge($params, $sqlparams);
         }
 
+        // These courses are exclusionary. Do not delete them.
         if (isset($criteria['courses'])) {
             [$sql, $sqlparams] = $DB->get_in_or_equal(explode("\n", $criteria['courses']), SQL_PARAMS_NAMED, 'course_', false);
             $extrasql .= ' AND shortname ' . $sql;

--- a/cleaner/courses/classes/clean.php
+++ b/cleaner/courses/classes/clean.php
@@ -30,13 +30,6 @@ class clean extends \local_datacleaner\clean {
     const TASK = 'Removing old courses';
 
     /**
-     * Needs cascade delete.
-     *
-     * @var bool
-     */
-    protected $needscascadedelete = true;
-
-    /**
      * Courses.
      *
      * @var array
@@ -91,16 +84,23 @@ class clean extends \local_datacleaner\clean {
                 "SELECT COUNT('x')
                    FROM {context}
               LEFT JOIN {course} ON {context}.instanceid = {course}.id
-                  WHERE contextlevel = 50
-                    AND {course}.id IS NULL"
+                  WHERE contextlevel = :contextlevel
+                    AND {course}.id IS NULL",
+                ['contextlevel' => CONTEXT_COURSE]
             );
             echo "\nWould delete " . $count . " context records that are currently lacking matching courses " .
                     "and those from courses to be deleted.\n";
         } else {
-            $DB->execute("DELETE FROM {context} USING {course}
-                                WHERE contextlevel = 50
-                                  AND {context}.instanceid = {course}.id
-                                  AND {course}.id IS NULL");
+            $DB->delete_records_select(
+                'context',
+                "contextlevel = :contextlevel
+                 AND NOT EXISTS (
+                     SELECT 1
+                       FROM {course}
+                      WHERE {course}.id = {context}.instanceid
+                 )",
+                ['contextlevel' => CONTEXT_COURSE]
+            );
         }
     }
 

--- a/cleaner/courses/tests/courses_test.php
+++ b/cleaner/courses/tests/courses_test.php
@@ -1,0 +1,176 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace cleaner_courses;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Unit test for the courses cleaner.
+ *
+ * @package cleaner_courses
+ * @copyright  2026 Catalyst IT
+ * @author     Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+#[CoversClass(clean::class)]
+final class courses_test extends \advanced_testcase {
+    /**
+     * Reset cleaner options before each test.
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+        new clean(['dryrun' => false, 'verbose' => false]);
+    }
+
+    /**
+     * The constructor should mark the cleaner as requiring cascade deletion
+     * when configured courses match the configured criteria.
+     */
+    public function test_constructor_sets_cascade_delete_for_matching_courses(): void {
+        $course = $this->getDataGenerator()->create_course(['shortname' => 'remove-me']);
+        set_config('minimumage', 0, 'cleaner_courses');
+
+        $cleaner = new clean();
+        $this->assertTrue($cleaner->needs_cascade_delete());
+
+        // Add a course to not delete.
+        set_config('courses', $course->shortname, 'cleaner_courses');
+        $cleaner = new clean();
+        $this->assertFalse($cleaner->needs_cascade_delete());
+    }
+
+    /**
+     * Function delete_courses() should remove the selected courses.
+     */
+    public function test_delete_courses_deletes_selected_courses(): void {
+        global $DB;
+
+        $course = $this->getDataGenerator()->create_course();
+        $this->assertTrue($DB->record_exists('course', ['id' => $course->id]));
+
+        clean::delete_courses([$course->id => $course->id]);
+
+        $this->assertFalse($DB->record_exists('course', ['id' => $course->id]));
+    }
+
+    /**
+     * Function delete_courses() should not modify records during a dry run.
+     */
+    public function test_delete_courses_does_not_delete_during_dry_run(): void {
+        global $DB;
+
+        $course = $this->getDataGenerator()->create_course();
+        new clean(['dryrun' => true]);
+
+        ob_start();
+        clean::delete_courses([$course->id => $course->id]);
+        $output = ob_get_clean();
+
+        $this->assertTrue($DB->record_exists('course', ['id' => $course->id]));
+        $this->assertStringContainsString('Would delete 1 courses', $output);
+    }
+
+    /**
+     * Function delete_dangling_course_contexts() should remove course contexts without
+     * a matching course while preserving valid course contexts.
+     */
+    public function test_delete_dangling_course_contexts(): void {
+        global $DB;
+
+        $course = $this->getDataGenerator()->create_course();
+        $validcontext = \context_course::instance($course->id);
+        $danglingcontextid = $DB->insert_record('context', (object) [
+            'contextlevel' => CONTEXT_COURSE,
+            'instanceid' => 987654321,
+            'path' => null,
+            'depth' => 0,
+            'locked' => 0,
+        ]);
+
+        $this->assertTrue($DB->record_exists('context', ['id' => $danglingcontextid]));
+
+        clean::delete_dangling_course_contexts();
+
+        $this->assertFalse($DB->record_exists('context', ['id' => $danglingcontextid]));
+        $this->assertTrue($DB->record_exists('context', ['id' => $validcontext->id]));
+    }
+
+    /**
+     * Function delete_dangling_course_contexts() should not remove any course contexts during a
+     * dry run.
+     */
+    public function test_delete_dangling_course_contexts_in_dryrun(): void {
+        global $DB;
+
+        $course = $this->getDataGenerator()->create_course();
+        $validcontext = \context_course::instance($course->id);
+        $danglingcontextid = $DB->insert_record('context', (object) [
+            'contextlevel' => CONTEXT_COURSE,
+            'instanceid' => 987654321,
+            'path' => null,
+            'depth' => 0,
+            'locked' => 0,
+        ]);
+
+        $this->assertTrue($DB->record_exists('context', ['id' => $danglingcontextid]));
+
+        new clean(['dryrun' => true]);
+        ob_start();
+        clean::delete_dangling_course_contexts();
+        $output = ob_get_clean();
+
+        $this->assertTrue($DB->record_exists('context', ['id' => $danglingcontextid]));
+        $this->assertTrue($DB->record_exists('context', ['id' => $validcontext->id]));
+        $this->assertStringContainsString('Would delete 1 context records', $output);
+    }
+
+    /**
+     * Function execute() should preserve selected courses and delete unselected courses.
+     */
+    public function test_execute_deletes_configured_courses_only(): void {
+        global $DB;
+
+        $selected = $this->getDataGenerator()->create_course(['shortname' => 'selected']);
+        $unselected = $this->getDataGenerator()->create_course(['shortname' => 'unselected']);
+        set_config('minimumage', 0, 'cleaner_courses');
+        set_config('courses', $selected->shortname, 'cleaner_courses');
+
+        new clean();
+        ob_start();
+        clean::execute();
+        ob_get_clean();
+
+        $this->assertTrue($DB->record_exists('course', ['id' => $selected->id]));
+        $this->assertFalse($DB->record_exists('course', ['id' => $unselected->id]));
+    }
+
+    /**
+     * Function execute() should report when no courses match the configured criteria.
+     */
+    public function test_execute_reports_when_no_courses_match(): void {
+        set_config('minimumage', 0, 'cleaner_courses');
+        set_config('courses', 'does-not-exist', 'cleaner_courses');
+
+        new clean();
+        ob_start();
+        clean::execute();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('No courses need deletion.', $output);
+    }
+}

--- a/cleaner/courses/version.php
+++ b/cleaner/courses/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2015072200;
+$plugin->version   = 2015072201;
 $plugin->release   = '2.3.2';
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->requires  = 2011120500; // Moodle 2.2 release and upwards.

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2026010113;
-$plugin->release   = 2026010113;
+$plugin->version   = 2026010114;
+$plugin->release   = 2026010114;
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->requires  = 2025041400; // Moodle 5.0 release and upwards.
 $plugin->supported = [500, 503];


### PR DESCRIPTION
Resolves #97 

- Refactor delete_dangling_course_contexts() to use correct, cross-platform SQL.
- Remove redundant $needscascadedelete declaration.
- Add unit tests.