### PR TITLE
Fix cron cleaner task lock key

### DIFF
--- a/cleaner/cron/classes/clean.php
+++ b/cleaner/cron/classes/clean.php
@@ -160,9 +160,9 @@ class clean extends \local_datacleaner\clean {
     public static function run_scheduled_task_with_locking(\core\task\scheduled_task $task): bool {
         $cronlockfactory = \core\lock\lock_config::get_lock_factory('cron');
 
-        // Use the same resource key core uses (DB classname, no leading slash)
+        // Use the same resource key core uses (DB classname, including the leading backslash)
         // so we contend on the same per-task lock as a real cron run.
-        $classname = trim(\core\task\manager::get_canonical_class_name($task), '\\');
+        $classname = \core\task\manager::get_canonical_class_name($task);
 
         if (!$lock = $cronlockfactory->get_lock($classname, 10)) {
             self::debug("Could not obtain lock to run scheduled task: {$classname}");

--- a/cleaner/cron/tests/clean_test.php
+++ b/cleaner/cron/tests/clean_test.php
@@ -244,6 +244,37 @@ final class clean_test extends \advanced_testcase {
     }
 
     /**
+     * A task already locked by core cron must not run again.
+     */
+    public function test_run_scheduled_task_with_locking_skips_locked_task(): void {
+        global $CFG;
+
+        $this->preventResetByRollback();
+        $CFG->task_logtostdout = true;
+        \core\cron::reset_user_cache();
+
+        // Use non-reentrant locks so contention is enforced within this process.
+        $CFG->lock_factory = \core\lock\db_record_lock_factory::class;
+
+        $classname = $this->register_marker_task();
+        $task = manager::get_scheduled_task($classname);
+        $factory = \core\lock\lock_config::get_lock_factory('cron');
+        $lock = $factory->get_lock($classname, 0);
+        $this->assertNotFalse($lock);
+
+        ob_start();
+        try {
+            $result = clean::run_scheduled_task_with_locking($task);
+        } finally {
+            ob_end_clean();
+            $lock->release();
+        }
+
+        $this->assertFalse($result);
+        $this->assertSame(0, ran_marker_task::$timesrun);
+    }
+
+    /**
      * run_scheduled_task_with_locking() should run the task through the cron
      * machinery and release the lock afterwards.
      */
@@ -266,7 +297,7 @@ final class clean_test extends \advanced_testcase {
 
         // The task lock must have been released: we can re-acquire it immediately.
         $factory = \core\lock\lock_config::get_lock_factory('cron');
-        $lock = $factory->get_lock(trim($classname, '\\'), 0);
+        $lock = $factory->get_lock($classname, 0);
         $this->assertNotFalse($lock);
         $lock->release();
     }

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2022020307;
-$plugin->release   = 2022020307;
+$plugin->version   = 2022020308;
+$plugin->release   = 2022020308;
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->requires  = 2021051700; // Moodle 3.11 release and upwards.
 $plugin->supported = [311, 405];


### PR DESCRIPTION
The class names and key always begin with a `\`: 

- https://github.com/moodle/moodle/blob/v3.11.0/lib/classes/task/manager.php#L1046-L1060
- https://github.com/moodle/moodle/blob/v3.11.0/lib/classes/task/manager.php#L244-L246
- https://github.com/moodle/moodle/blob/v3.11.0/lib/classes/task/manager.php#L706-L722
  - (`$classname = '\\' . $record->classname;` is dead code, it does nothing)
- https://github.com/moodle/moodle/blob/v3.11.0/admin/cli/scheduled_task.php#L149-L154